### PR TITLE
Bump api version for /api/admin/pipelines to v6 for gocd 18.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,27 +11,6 @@ from a git repository.
 [![Quality Gate](https://sonarqube.com/api/badges/measure?key=gocdpb&metric=code_smells)](https://sonarqube.com/dashboard/index/gocdpb)
 
 
-Supported GoCD versions
------------------------
-
-The GoCD REST API is continuously developing, and the
-*GoCD Pipeline Builder* uses a lot of the newer APIs,
-so you have to use a fairly current GoCD version to
-use this software. 
-
-If this software doesn't work because your GoCD server
-is older than the one we test it with, please upgrade
-your GoCD server. If this software doesn't work with
-the latest released GoCD from Thoughtworks, please file
-an issue.
-
-Unfortunately, the GoCD server isn't very explicit 
-in its error messages. If an API changes to use e.g.
-`application/vnd.go.cd.v4+json` and we call it with 
-`application/vnd.go.cd.v3+json`, we'll simply get an 
-HTTP status 404 as response.
-
-
 Overview
 --------
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 if __name__ == '__main__':
     setup(
         name='gocdpb',
-        version='9.1',
+        version='9.2',
         description='Configure GoCD pipeline from the commandline.',
         long_description=(
             'The Go CD Pipeline Builder is designed to have the same '

--- a/src/gocdpb/goserver_adapter.py
+++ b/src/gocdpb/goserver_adapter.py
@@ -98,7 +98,7 @@ class Goserver(object):
     def get_pipeline_config(self, pipeline_name):
         path = "/api/admin/pipelines/" + pipeline_name
         headers = {
-            'Accept': 'application/vnd.go.cd.v5+json'
+            'Accept': 'application/vnd.go.cd.v6+json'
         }
         response = self.request('get', path, headers=headers)
         if response.status_code != 200:
@@ -112,7 +112,7 @@ class Goserver(object):
         path = "/api/admin/pipelines/" + pipeline_name
         data = json.dumps(pipeline)
         headers = {
-            'Accept': 'application/vnd.go.cd.v5+json',
+            'Accept': 'application/vnd.go.cd.v6+json',
             'Content-Type': 'application/json',
             'If-Match': etag
         }
@@ -124,7 +124,7 @@ class Goserver(object):
     def delete_pipeline_config(self, pipeline_name):
         path = "/api/admin/pipelines/" + pipeline_name
         headers = {
-            'Accept': 'application/vnd.go.cd.v5+json',
+            'Accept': 'application/vnd.go.cd.v6+json',
         }
         response = self.request('delete', path, headers=headers)
         if response.status_code != 200:

--- a/src/gocdpb/goserver_adapter.py
+++ b/src/gocdpb/goserver_adapter.py
@@ -88,7 +88,7 @@ class Goserver(object):
         path = "/api/admin/pipelines"
         data = json.dumps(pipeline)
         headers = {
-            'Accept': 'application/vnd.go.cd.v6+json',
+            'Accept': 'application/vnd.go.cd+json',
             'Content-Type': 'application/json'
         }
         response = self.request('post', path, data=data, headers=headers)
@@ -98,7 +98,7 @@ class Goserver(object):
     def get_pipeline_config(self, pipeline_name):
         path = "/api/admin/pipelines/" + pipeline_name
         headers = {
-            'Accept': 'application/vnd.go.cd.v6+json'
+            'Accept': 'application/vnd.go.cd+json'
         }
         response = self.request('get', path, headers=headers)
         if response.status_code != 200:
@@ -112,7 +112,7 @@ class Goserver(object):
         path = "/api/admin/pipelines/" + pipeline_name
         data = json.dumps(pipeline)
         headers = {
-            'Accept': 'application/vnd.go.cd.v6+json',
+            'Accept': 'application/vnd.go.cd+json',
             'Content-Type': 'application/json',
             'If-Match': etag
         }
@@ -124,7 +124,7 @@ class Goserver(object):
     def delete_pipeline_config(self, pipeline_name):
         path = "/api/admin/pipelines/" + pipeline_name
         headers = {
-            'Accept': 'application/vnd.go.cd.v6+json',
+            'Accept': 'application/vnd.go.cd+json',
         }
         response = self.request('delete', path, headers=headers)
         if response.status_code != 200:
@@ -133,7 +133,7 @@ class Goserver(object):
 
     def unpause(self, pipeline_name):
         headers = {
-            'Accept': 'application/vnd.go.cd.v1+json',
+            'Accept': 'application/vnd.go.cd+json',
             'X-GoCD-Confirm': 'true'
         }
         path = "/api/pipelines/" + pipeline_name + "/unpause"
@@ -200,7 +200,7 @@ class Goserver(object):
             data_structure["agents"] = agents
         data = json.dumps(data_structure)
         headers = {
-            'Accept': 'application/vnd.go.cd.v2+json',
+            'Accept': 'application/vnd.go.cd+json',
             'Content-Type': 'application/json'
         }
         response = self.request('patch', path, data=data, headers=headers)

--- a/src/gocdpb/goserver_adapter.py
+++ b/src/gocdpb/goserver_adapter.py
@@ -88,7 +88,7 @@ class Goserver(object):
         path = "/api/admin/pipelines"
         data = json.dumps(pipeline)
         headers = {
-            'Accept': 'application/vnd.go.cd.v5+json',
+            'Accept': 'application/vnd.go.cd.v6+json',
             'Content-Type': 'application/json'
         }
         response = self.request('post', path, data=data, headers=headers)


### PR DESCRIPTION
since gocd 19.8.0 it is now possible to omit the api version in api calls. As this lib is not tied to a gocd version it's probably sensible to remove them. I don't know if you want to merge this upstream but it's up to you :). Cheers!